### PR TITLE
TEST: checksum drift (do not merge)

### DIFF
--- a/project/deployment/scripts/install.sh
+++ b/project/deployment/scripts/install.sh
@@ -1497,4 +1497,4 @@ main() {
 trap 'error "Installation interrupted. Run script again to retry."; exit 130' INT TERM
 
 # Run main function with all arguments
-main "$@"
+main "$@"# intentional drift test - 2026-04-18T16:42:09Z


### PR DESCRIPTION
Intentional test of the new `verify-install-checksum.yml` CI guard.

Expected: CI run fails with a clear error naming expected vs actual hash and giving the fix command.

Will be closed without merging.